### PR TITLE
Set up an easier set of getters

### DIFF
--- a/src/djson/json.hpp
+++ b/src/djson/json.hpp
@@ -26,7 +26,16 @@ namespace djson {
   using Node = std::variant<Number, String, Boolean, Null, Array, Object>;
   // I do not 100% like this
   /// A ordered list enclosed by square brackets
-  struct Array : public std::vector<Node> {};
+  struct Array : public std::vector<Node> {
+    template <typename T>
+    const T &get (std::vector<Node>::size_type key) const {
+      return std::get<T> (this->operator[] (key));
+    }
+    template <typename T>
+    T &get (std::vector<Node>::size_type key) {
+      return std::get<T> (this->operator[] (key));
+    }
+  };
   /// @brief A object enclosed by curly brackets (that contains named values)
   class Object {
     // I want to keep the order or the keys
@@ -43,7 +52,11 @@ namespace djson {
     /// return sthe keys in order of declation
     const std::vector<std::string> &Keys () const;
     template <typename T>
-    T get (const std::string &key) const {
+    const T &get (const std::string &key) const {
+      return std::get<T> (objects.at (key));
+    }
+    template <typename T>
+    T &get (const std::string &key) {
       return std::get<T> (objects.at (key));
     }
     /// assigns the value to the argument, it deduces the type

--- a/tests/test_array.cpp
+++ b/tests/test_array.cpp
@@ -14,3 +14,11 @@ TEST_CASE ("Array Set Numbers", "[Array][crude]") {
   REQUIRE (std::holds_alternative<djson::Number> (x[1]));
   REQUIRE (std::get<djson::Number> (x[1]) == Catch::Approx (15));
 }
+
+TEST_CASE ("Set with get array", "[crude]") {
+  djson::Array obj ({djson::Number (1), djson::Number (2), djson::Number (3)});
+
+  REQUIRE (std::get<djson::Number> (obj[0]) == Catch::Approx (1));
+  obj.get<djson::Number> (0) = djson::Number (2);
+  REQUIRE (std::get<djson::Number> (obj[0]) == Catch::Approx (2));
+}

--- a/tests/test_object.cpp
+++ b/tests/test_object.cpp
@@ -79,3 +79,12 @@ TEST_CASE ("Test Inequality", "[crude]") {
   y["inside"] = inside;
   REQUIRE (x != y);
 }
+
+TEST_CASE ("Set with get", "[crude]") {
+  djson::Object obj;
+
+  obj["num"] = djson::Number (1);
+  REQUIRE (std::get<djson::Number> (obj["num"]) == Catch::Approx (1));
+  obj.get<djson::Number> ("num") = djson::Number (2);
+  REQUIRE (std::get<djson::Number> (obj["num"]) == Catch::Approx (2));
+}


### PR DESCRIPTION
Adding a easeier set of getters to not nest calls of `std::get` within calls of `std::get`